### PR TITLE
Create Node.js CLI and use Unicode for I/O instructions

### DIFF
--- a/ws_asm.js
+++ b/ws_asm.js
@@ -197,12 +197,10 @@ globalThis.ws_asm  = (function() {
   };
 
   const getStringArray = function (str) {
-    const arr = str.split('');
     const result = [];
     let escape = false;
     let chCode = "";
-    for (let i = 1; i < arr.length - 1; i++) {
-      const ch = arr[i];
+    for (const ch of str.slice(1, -1)) {
       if (chCode) {
         if (/[0-9]/.test(ch)) {
           chCode += ch;
@@ -220,19 +218,19 @@ globalThis.ws_asm  = (function() {
         } else if (/[0-9]/.test(ch)) {
           chCode += ch;
         } else {
-          result.push(BigInt(ch.charCodeAt(0)));
+          result.push(BigInt(ch.codePointAt(0)));
         }
         escape = false;
       } else if (ch === '\\') {
         escape = true;
       } else {
-        result.push(BigInt(ch.charCodeAt(0)));
+        result.push(BigInt(ch.codePointAt(0)));
       }
     }
     if (chCode) {
       result.push(BigInt(chCode));
     }
-    if (arr[0] === '"') {
+    if (str[0] === '"') {
       result.push(0n);
     }
     return result;

--- a/ws_cli.js
+++ b/ws_cli.js
@@ -1,0 +1,66 @@
+const fs = require("fs");
+const path = require("path");
+const process = require("process");
+
+const libRoot = path.join(__dirname, "example");
+const localRoot = process.cwd();
+
+const abort = function (err, code) {
+  process.stderr.write("Error: " + err + "\n");
+  process.exit(code);
+};
+
+// Provide a minimal ws_fs with only what's needed for ws_asm.
+globalThis.ws_fs = (function () {
+  const self = {
+    files: {},
+    getFile: function (fileName) {
+      if (!self.files[fileName]) {
+        let src;
+        try {
+          src = fs.readFileSync(path.join(localRoot, fileName), "utf8");
+        } catch (err1) {
+          try {
+            src = fs.readFileSync(path.join(libRoot, fileName), "utf8");
+          } catch (err2) {
+            const libRelative = path.relative(localRoot, libRoot);
+            abort("no such file '" + fileName + "' in '.' or '" + libRelative + "'", 1);
+          }
+        }
+        self.files[fileName] = { src: src };
+      }
+      return self.files[fileName];
+    },
+    openFile: function (file) {
+      return file.src;
+    }
+  };
+  return self;
+})();
+
+require("./ws_util.js");
+require("./ws_core.js");
+require("./ws_asm.js");
+
+if (process.argv.length !== 3) {
+  abort("Usage: ws_cli.js <file>", 2);
+}
+const fileName = process.argv[2];
+
+let compile;
+if (/\.ws$/i.test(fileName)) {
+  compile = ws.compile;
+} else if (/\.wsa$/i.test(fileName)) {
+  compile = ws_asm.compile;
+} else {
+  abort("extension must be '.ws' or '.wsa'", 2);
+}
+
+let src;
+try {
+  src = fs.readFileSync(fileName, "utf8");
+} catch (err) {
+  abort("no such file '" + fileName + "'", 2);
+}
+const program = compile(src);
+process.stdout.write(program.getWsSrc());

--- a/ws_cli.js
+++ b/ws_cli.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const fs = require('fs');
 const path = require('path');
 const process = require('process');
@@ -11,8 +13,8 @@ const usage = `Usage: ws_cli.js [options] [--] <file>
 
 Modes:
   --run, -r      Interpret the program (default)
-  --asm, -a      Assemble the program to Whitespace
-  --disasm, -d   Disassemble the program to Whitespace assembly
+  --ws, -w       Dump the program as Whitespace
+  --wsa, -a      Dump the program as Whitespace assembly
 
 Options:
   --opt, -o      Optimize the program
@@ -36,10 +38,10 @@ for (let i = 2; i < process.argv.length; i++) {
   // Long options
   if (arg === '--run') {
     setMode('run');
-  } else if (arg === '--asm') {
-    setMode('asm');
-  } else if (arg === '--disasm') {
-    setMode('disasm');
+  } else if (arg === '--ws') {
+    setMode('ws');
+  } else if (arg === '--wsa') {
+    setMode('wsa');
   } else if (arg === '--opt') {
     optimize = true;
   } else if (arg === '--verbose') {
@@ -59,10 +61,10 @@ for (let i = 2; i < process.argv.length; i++) {
     for (const opt of arg.slice(1)) {
       if (opt === 'r') {
         setMode('run');
+      } else if (opt === 'w') {
+        setMode('ws');
       } else if (opt === 'a') {
-        setMode('asm');
-      } else if (opt === 'd') {
-        setMode('disasm');
+        setMode('wsa');
       } else if (opt === 'o') {
         optimize = true;
       } else if (opt === 'v') {
@@ -228,9 +230,9 @@ const run = function (program) {
 
 if (mode === 'run') {
   run(program);
-} else if (mode === 'asm') {
+} else if (mode === 'ws') {
   process.stdout.write(program.getWsSrc());
-} else if (mode === 'disasm') {
+} else if (mode === 'wsa') {
   for (const instr of program.getAsmSrc()) {
     let str = instr.str;
     // Do not indent labels

--- a/ws_cli.js
+++ b/ws_cli.js
@@ -1,35 +1,98 @@
-const fs = require("fs");
-const path = require("path");
-const process = require("process");
-
-const libRoot = path.join(__dirname, "example");
-const localRoot = process.cwd();
+const fs = require('fs');
+const path = require('path');
+const process = require('process');
 
 const abort = function (err, code) {
-  process.stderr.write("Error: " + err + "\n");
+  process.stderr.write(err + '\n');
   process.exit(code);
 };
+
+const usage = `Usage: ws_cli.js [options] [--] <file>
+
+  --run, -r      Interpret the program
+  --asm, -a      Assemble the program to Whitespace
+  --disasm, -d   Disassemble the program to Whitespace assembly
+  --verbose, -v  Use verbose output
+  --help, -h     Print help`;
+
+let filename = null;
+let mode = null;
+let verbose = false;
+
+for (let i = 2; i < process.argv.length; i++) {
+  const arg = process.argv[i];
+  let newMode = null;
+  if (arg === '--run' || arg === '-r') {
+    newMode = 'run';
+  } else if (arg === '--asm' || arg === '-a') {
+    newMode = 'asm';
+  } else if (arg === '--disasm' || arg === '-d') {
+    newMode = 'disasm';
+  } else if (arg === '--verbose' || arg === '-v') {
+    verbose = true;
+    continue;
+  } else if (arg === '--help' || arg === '-h') {
+    abort(usage);
+  } else if (arg === '--') {
+    if (filename != null) {
+      abort('Usage error: Too many arguments', 2);
+    }
+    filename = process.argv[i + 1];
+    break;
+  } else if (arg.startsWith('-')) {
+    abort(`Usage error: Unknown option: '${arg}'`, 2);
+  } else {
+    if (filename == null) {
+      filename = arg;
+      continue;
+    } else {
+      abort('Usage error: Too many arguments', 2);
+    }
+  }
+  if (mode != null && newMode !== mode) {
+    abort(`Usage error: Mode '${mode}' is mutually exclusive with '${newMode}'`, 2);
+  }
+  mode = newMode;
+}
+
+if (filename == null) {
+  if (process.argv.length > 2) {
+    abort('Usage error: No filename given', 2);
+  } else {
+    abort(usage, 2);
+  }
+}
+if (mode == null) {
+  mode = 'run';
+}
+if (!verbose) {
+  console.log = function () {};
+  console.warn = function () {};
+  console.error = function () {};
+}
+
+const libRoot = path.join(__dirname, 'example');
+const localRoot = process.cwd();
 
 // Provide a minimal ws_fs with only what's needed for ws_asm.
 globalThis.ws_fs = (function () {
   const self = {
     files: {},
-    getFile: function (fileName) {
-      if (!self.files[fileName]) {
+    getFile: function (filename) {
+      if (!self.files[filename]) {
         let src;
         try {
-          src = fs.readFileSync(path.join(localRoot, fileName), "utf8");
+          src = fs.readFileSync(path.join(localRoot, filename), 'utf8');
         } catch (err1) {
           try {
-            src = fs.readFileSync(path.join(libRoot, fileName), "utf8");
+            src = fs.readFileSync(path.join(libRoot, filename), 'utf8');
           } catch (err2) {
-            const libRelative = path.relative(localRoot, libRoot);
-            abort("no such file '" + fileName + "' in '.' or '" + libRelative + "'", 1);
+            return null;
           }
         }
-        self.files[fileName] = { src: src };
+        self.files[filename] = { src: src };
       }
-      return self.files[fileName];
+      return self.files[filename];
     },
     openFile: function (file) {
       return file.src;
@@ -38,29 +101,44 @@ globalThis.ws_fs = (function () {
   return self;
 })();
 
-require("./ws_util.js");
-require("./ws_core.js");
-require("./ws_asm.js");
-
-if (process.argv.length !== 3) {
-  abort("Usage: ws_cli.js <file>", 2);
-}
-const fileName = process.argv[2];
+require('./ws_util.js');
+require('./ws_core.js');
+require('./ws_asm.js');
 
 let compile;
-if (/\.ws$/i.test(fileName)) {
+if (/\.ws$/i.test(filename)) {
   compile = ws.compile;
-} else if (/\.wsa$/i.test(fileName)) {
+} else if (/\.wsa$/i.test(filename)) {
   compile = ws_asm.compile;
 } else {
-  abort("extension must be '.ws' or '.wsa'", 2);
+  abort(`Error: Extension must be '.ws' or '.wsa'`, 2);
 }
 
 let src;
 try {
-  src = fs.readFileSync(fileName, "utf8");
+  src = fs.readFileSync(filename, 'utf8');
 } catch (err) {
-  abort("no such file '" + fileName + "'", 2);
+  abort(`Error: No such file: '${filename}'`, 2);
 }
-const program = compile(src);
-process.stdout.write(program.getWsSrc());
+
+let program;
+try {
+  program = compile(src);
+} catch (err) {
+  abort(`Compile error: ${err.message || err}`, 1);
+}
+
+if (mode === 'run') {
+  process.stdout.write('TODO\n');
+} else if (mode === 'asm') {
+  process.stdout.write(program.getWsSrc());
+} else if (mode === 'disasm') {
+  for (const instr of program.getAsmSrc()) {
+    let str = instr.str;
+    // Do not indent labels
+    if (instr.IP != null) {
+      str = '  ' + instr.str;
+    }
+    process.stdout.write(str + '\n');
+  }
+}

--- a/ws_cli.js
+++ b/ws_cli.js
@@ -9,7 +9,7 @@ const abort = function (err, code) {
   process.exit(code);
 };
 
-const usage = `Usage: ws_cli.js [options] [--] <file>
+const usage = `Usage: ${path.basename(process.argv[1])} [options] [--] <file>
 
 Modes:
   --run, -r      Interpret the program (default)

--- a/ws_cli.js
+++ b/ws_cli.js
@@ -163,9 +163,6 @@ if (optimize) {
 const run = function (program) {
   const env = ws.env();
 
-  let buffer = '';
-  process.stdin.setEncoding('utf8');
-
   const continueRun = function () {
     try {
       env.runProgram(program);
@@ -180,11 +177,23 @@ const run = function (program) {
     }
   };
 
+  let buffer = '';
+  let atEof = false;
+
+  process.stdin.setEncoding('utf8');
+  process.stdin.once('close', function (hadError) {
+    atEof = true;
+    continueRun();
+  });
+
   env.print = function (val) {
     process.stdout.write(val.toString());
   };
 
   const read = function () {
+    if (atEof) {
+      throw 'Read at EOF';
+    }
     process.stdin.once('data', function (data) {
       if (env.running) {
         buffer += data.toString('utf8');

--- a/ws_core.js
+++ b/ws_core.js
@@ -231,7 +231,7 @@ globalThis.ws = {
       for (const label in this.labels) {
         const inst = this.programStack[this.labels[label]];
         if (inst) {
-          if ($.inArray(label, inst.labels) < 0) {
+          if (inst.labels.indexOf(label) < 0) {
             inst.labels.push(label);
           }
         } else {

--- a/ws_core.js
+++ b/ws_core.js
@@ -455,7 +455,7 @@ globalThis.ws = {
   WsPrintChar: function() {
     this.run = function(env) {
       const ch = env.stackPop();
-      env.print(String.fromCharCode(Number(ch & 0xffffffffn)));
+      env.print(String.fromCodePoint(Number(ch & 0xffffffffn)));
       env.register.IP++;
     };
     this.getAsm = asmWithNoParam;
@@ -549,7 +549,7 @@ globalThis.ws = {
       if (typeof ch === "number") {
         val = ch;
       } else if (typeof ch === "string") {
-        val = ch.charCodeAt(0);
+        val = ch.codePointAt(0);
       }
       if (typeof val !== "undefined") {
         env.heap.store(addr, BigInt(val));

--- a/ws_core.js
+++ b/ws_core.js
@@ -138,7 +138,13 @@ globalThis.ws = {
         this.register.IP = this.callStack.pop() + 1;
       },
       print: function (s) {
-        console.error('Print unimplemented: ' + s);
+        throw 'Print unimplemented';
+      },
+      readChar: function () {
+        throw 'Read char unimplemented';
+      },
+      readNum: function () {
+        throw 'Read num unimplemented';
       },
       beforeInstructionRun: function (env) {
       },

--- a/ws_ide.js
+++ b/ws_ide.js
@@ -46,7 +46,7 @@ globalThis.ws_ide = (function () {
     return fn.replace(/.*\.([^.]+)$/, '$1');
   };
 
-  getExecPath = function(fn, vms) {
+  const getExecPath = function(fn, vms) {
     if (typeof vms === 'undefined') {
       vms = ws_fs.getFileNames(/^vm\//);
     }
@@ -69,7 +69,7 @@ globalThis.ws_ide = (function () {
     return [];
   };
 
-  getCompilePath = function(fn, wcs) {
+  const getCompilePath = function(fn, wcs) {
     if (typeof wcs === 'undefined') {
       wcs = ws_fs.getFileNames(/^wc\/.*\.wsa?$/);
     }
@@ -562,10 +562,11 @@ globalThis.ws_ide = (function () {
           }
         }
 
+        ws_ide.inputStream = [];
         for (let i = 1; i < execPath.length; i++) {
-          ws_ide.inputStream = [...ws_fs.openFile(ws_fs.getFile(execPath[i])), null];
+          ws_ide.inputStream = ws_ide.inputStream.concat([...ws_fs.openFile(ws_fs.getFile(execPath[i])), null]);
         }
-        ws_ide.inputStream = [...ws_ide.openFile.src, null];
+        ws_ide.inputStream = ws_ide.inputStream.concat([...ws_ide.openFile.src, null]);
 
         ws_ide.initEnv();
         ws_ide.env.running = true;

--- a/ws_ide.js
+++ b/ws_ide.js
@@ -446,8 +446,8 @@ globalThis.ws_ide = (function () {
           userInput += e.key;
         } else if (e.key == 'Backspace') {
           if (txt && txt.length > 0 && txt.slice(-1) != '\n') {
-            printArea.text(txt.slice(0, -1));
-            userInput.slice(0, -1);
+            printArea.text([...txt].slice(0, -1).join(''));
+            userInput = [...userInput].slice(0, -1).join('');
           }
         } else if (e.key == 'Enter') {
           printArea.text(txt + '\n');

--- a/ws_ide.js
+++ b/ws_ide.js
@@ -563,9 +563,9 @@ globalThis.ws_ide = (function () {
         }
 
         for (let i = 1; i < execPath.length; i++) {
-          ws_ide.inputStream = ws_fs.openFile(ws_fs.getFile(execPath[i])).split('').concat([null]);
+          ws_ide.inputStream = [...ws_fs.openFile(ws_fs.getFile(execPath[i])), null];
         }
-        ws_ide.inputStream = ws_ide.openFile.src.split('').concat([null]);
+        ws_ide.inputStream = [...ws_ide.openFile.src, null];
 
         ws_ide.initEnv();
         ws_ide.env.running = true;
@@ -672,7 +672,7 @@ globalThis.ws_ide = (function () {
     handleUserInput: function (selector, code) {
       if (typeof code === 'undefined') code = '\n';
 
-      ws_ide.inputStream = ws_ide.inputStream.concat(code.split(''));
+      ws_ide.inputStream = ws_ide.inputStream.concat([...code]);
       this.continueRun();
       return false;
     },
@@ -816,9 +816,9 @@ globalThis.ws_ide = (function () {
 
         ws_ide.inputStream = [];
         for (let i = 1; i < compilePath.length; i++) {
-          ws_ide.inputStream = ws_ide.inputStream.concat(ws_fs.openFile(ws_fs.getFile(compilePath[i].file)).split('').concat([null]));
+          ws_ide.inputStream = ws_ide.inputStream.concat([...ws_fs.openFile(ws_fs.getFile(compilePath[i].file)), null]);
         }
-        ws_ide.inputStream = ws_ide.inputStream.concat(ws_ide.openFile.src.split('').concat([null]));
+        ws_ide.inputStream = ws_ide.inputStream.concat([...ws_ide.openFile.src, null]);
         ws_ide.initEnv();
         ws_ide.env.running = true;
         let output = '';

--- a/ws_ide.js
+++ b/ws_ide.js
@@ -215,7 +215,7 @@ globalThis.ws_ide = (function () {
     try {
       return BigInt(numStr);
     } catch (e) {
-      throw "Illegal number entered!";
+      throw "Invalid number format: " + numStr.trim();
     }
   };
 

--- a/ws_util.js
+++ b/ws_util.js
@@ -40,7 +40,7 @@ globalThis.ws_util = (function () {
 
     StrArr: function(str) {
       return {
-        arr: str.split(''),
+        arr: [...str],
         pos: 0,
         line: 1,
         col: 1,


### PR DESCRIPTION
I find it useful to use an assembler in automated scripts when coding in Whitespace assembly and I've used yours and others for that purposed in various kludges over the years. This PR adds a CLI for Whitelips, that can interpret, assemble, or disassemble a program.

I also changed the interpreter to work with Unicode codepoints for the I/O instructions, to match the reference interpreter and the new CLI, as well as Whitespace assembly string literals. Those changes boil down to replacing `str.split('')` with `[...str]` or `for`-`of` loops and `charCodeAt` with `codePointAt`, which are more recent UTF-8–aware versions.

Now that I'm building my own assembler (not yet published), with the goal of unifying all Whitespace assembly syntax by detecting the dialect on the fly, I found several bugs in Whitelips. Particularly with parsing, label semantics, macro substitution, and error handling. I'll have PRs for those soon.